### PR TITLE
Fix <f8 numpy type for imageseries

### DIFF
--- a/nwb_explorer/nwb_model_interpreter/nwb_reader.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_reader.py
@@ -268,7 +268,7 @@ class NWBReader:
 
     @staticmethod
     def img_to_string(plottable_image):
-        img = Img.fromarray(plottable_image)
+        img = Img.fromarray(plottable_image.astype('uint8'), 'RGBA')
         output = BytesIO()
         img.save(output, format='PNG')
         output.seek(0, 0)

--- a/nwb_explorer/nwb_model_interpreter/nwb_reader.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_reader.py
@@ -268,7 +268,10 @@ class NWBReader:
 
     @staticmethod
     def img_to_string(plottable_image):
-        img = Img.fromarray(plottable_image.astype('uint8'), 'RGBA')
+        if plottable_image.dtype == np.uint8:
+            img = Img.fromarray(plottable_image)
+        else:
+            img = Img.fromarray(plottable_image.astype('uint8'))
         output = BytesIO()
         img.save(output, format='PNG')
         output.seek(0, 0)

--- a/test/utils.py
+++ b/test/utils.py
@@ -65,7 +65,7 @@ def create_image(name, nwbfile, external_storage):
     n = len(formats)
     
     if  external_storage:
-        base_uri = "https://raw.githubusercontent.com/MetaCell/nwb-explorer/feature/60/test/images/"
+        base_uri = "https://raw.githubusercontent.com/MetaCell/nwb-explorer/development/test/images/"
     else:
         base_uri = "test/images/"
     


### PR DESCRIPTION
Small change to include TwoPhotonSeries example. Also changing default branch for example images to dev