### PR TITLE
Support multi-pod for single user in k8s #80

### DIFF
--- a/k8s/Dockerfile-hub
+++ b/k8s/Dockerfile-hub
@@ -1,4 +1,4 @@
-FROM jupyterhub/k8s-hub:7f6781e
+FROM jupyterhub/k8s-hub:0.9-c9ee61d
     
 COPY --chown=1000:1000 page.html /usr/local/share/jupyterhub/templates/page.html
 COPY --chown=1000:1000 spawn_pending.html /usr/local/share/jupyterhub/templates/spawn_pending.html

--- a/k8s/auth.py
+++ b/k8s/auth.py
@@ -32,11 +32,16 @@ class TmpAuthenticateHandler(BaseHandler):
 
         user = yield gen.maybe_future(self.process_user(raw_user, self))
         
-        server_name = str(uuid.uuid4()).split('-').pop()
+        server_name = ''
+        redirection = self.get_next_url(user)
+        user.spawners[server_name].environment["NWBFILE"] = ''
+
         if 'hub/nwbfile=' in self.request.uri:
+            server_name = str(uuid.uuid4()).split('-').pop()
+            redirection = f'/hub/spawn/{user.name}/{server_name}'
             user.spawners[server_name].environment["NWBFILE"] = self.request.uri.split('=').pop()
         
-        self.redirect(f'{self.get_next_url(user)}/{user.name}/{server_name}')
+        self.redirect(redirection)
 
 
 class TmpAuthenticator(Authenticator):

--- a/k8s/auth.py
+++ b/k8s/auth.py
@@ -17,15 +17,26 @@ class TmpAuthenticateHandler(BaseHandler):
     @gen.coroutine
     def get(self):
 
-        username = str(uuid.uuid4())
-        raw_user = self.user_from_username(username)
-        self.set_login_cookie(raw_user)
+        raw_user = yield self.get_current_user()
+
+        if raw_user:
+            if self.force_new_server and raw_user.running:
+                status = yield raw_user.spawner.poll_and_notify()
+                if status is None:
+                    yield self.stop_single_user(raw_user)
+            
+        else:
+            username = str(uuid.uuid4())
+            raw_user = self.user_from_username(username)
+            self.set_login_cookie(raw_user)
+
         user = yield gen.maybe_future(self.process_user(raw_user, self))
         
+        server_name = str(uuid.uuid4()).split('-').pop()
         if 'hub/nwbfile=' in self.request.uri:
-            user.spawners[''].environment["NWBFILE"] = self.request.uri.split('=')[-1]
-
-        self.redirect(self.get_next_url(user))
+            user.spawners[server_name].environment["NWBFILE"] = self.request.uri.split('=').pop()
+        
+        self.redirect(f'{self.get_next_url(user)}/{user.name}/{server_name}')
 
 
 class TmpAuthenticator(Authenticator):


### PR DESCRIPTION
path `/` send the user to the default nwb-explorer

path `/nwbfile=something` spawns a new container and saves `something` as env var  in NWBFILE