### PR TITLE
Update pynwb to 1.2.1

### DIFF
--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -18,6 +18,7 @@ from pygeppetto.model.types.types import TextType, ImportType, CompositeType
 from pygeppetto.model.values import Image, Text, ImportValue, StringArray
 from pygeppetto.model.variables import Variable, TypeToValueMap
 
+
 nwb_geppetto_mappers = []
 
 
@@ -197,10 +198,19 @@ class GenericCompositeMapper(NWBGeppettoMapper):
         if hasattr(obj_dict, 'items'):
             items = obj_dict.items()
         elif is_collection(obj_dict):
-            items = (k if isinstance(obj_dict[k], bool) (obj_dict[k].name, obj_dict[k]) else None for k in range(len(obj_dict)))
+            items = self.collection_items(obj_dict)
         else:
             items = ()
         return items
+
+    def collection_items(self, obj_dict):
+        items=[]
+        for k in range(len(obj_dict)):
+            if hasattr(obj_dict[k], "name"):
+                items.append((obj_dict[k].name, obj_dict[k]))
+            else:
+                None
+        return items;
 
     def sanitize(self, key):
         return ''.join(k if k.isalnum() else '_' for k in key)

--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -5,7 +5,7 @@ from h5py.h5r import Reference
 from pygeppetto.model import Pointer, GenericArray, PointerElement
 
 from pynwb import TimeSeries
-from pynwb.core import NWBData
+from hdmf.common import ElementIdentifiers, VectorData
 from pynwb.core import LabelledDict
 from pynwb.file import Subject
 from pynwb.core import DynamicTable
@@ -103,7 +103,7 @@ class ImportValueMapper(NWBGeppettoMapper):
 
 class GenericCompositeMapper(NWBGeppettoMapper):
     generic = True
-    excluded_types = (NWBData)
+    excluded_types = (ElementIdentifiers, VectorData)
 
     def __init__(self, model_factory, nwb_geppetto_library):
         super().__init__(model_factory, nwb_geppetto_library)
@@ -197,7 +197,7 @@ class GenericCompositeMapper(NWBGeppettoMapper):
         if hasattr(obj_dict, 'items'):
             items = obj_dict.items()
         elif is_collection(obj_dict):
-            items = ((obj_dict[k].name, obj_dict[k]) for k in range(len(obj_dict)))
+            items = (k if isinstance(obj_dict[k], bool) (obj_dict[k].name, obj_dict[k]) else None for k in range(len(obj_dict)))
         else:
             items = ()
         return items
@@ -272,7 +272,7 @@ class SimpleArrayMapper(NWBGeppettoMapper):
 class VectorDataMapper(NWBGeppettoMapper):
 
     def creates(self, pynwb_obj):
-        return isinstance(pynwb_obj, NWBData)
+        return isinstance(pynwb_obj, VectorData)
 
     def create_variable(self, name, pynwb_obj, parent_obj):
         return self.create_variable_base(name, tuple(self.get_value(v) for v in pynwb_obj.data[()]))

--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -5,7 +5,7 @@ from h5py.h5r import Reference
 from pygeppetto.model import Pointer, GenericArray, PointerElement
 
 from pynwb import TimeSeries
-from pynwb.core import NWBBaseType, ElementIdentifiers, VectorData
+from pynwb.core import NWBData
 from pynwb.core import LabelledDict
 from pynwb.file import Subject
 from pynwb.core import DynamicTable
@@ -103,7 +103,7 @@ class ImportValueMapper(NWBGeppettoMapper):
 
 class GenericCompositeMapper(NWBGeppettoMapper):
     generic = True
-    excluded_types = (ElementIdentifiers, VectorData)
+    excluded_types = (NWBData)
 
     def __init__(self, model_factory, nwb_geppetto_library):
         super().__init__(model_factory, nwb_geppetto_library)
@@ -272,7 +272,7 @@ class SimpleArrayMapper(NWBGeppettoMapper):
 class VectorDataMapper(NWBGeppettoMapper):
 
     def creates(self, pynwb_obj):
-        return isinstance(pynwb_obj, VectorData)
+        return isinstance(pynwb_obj, NWBData)
 
     def create_variable(self, name, pynwb_obj, parent_obj):
         return self.create_variable_base(name, tuple(self.get_value(v) for v in pynwb_obj.data[()]))

--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -274,7 +274,7 @@ class SimpleArrayMapper(NWBGeppettoMapper):
         return is_collection(value) and value and is_metadata(next(iter(value)))
 
     def create_variable(self, name, pynwb_obj, parent_obj):
-        value = StringArray(str(v) for v in pynwb_obj)
+        value = StringArray(tuple(str(v) for v in pynwb_obj))
         array_variable = self.model_factory.create_simple_array_variable(name, value)
         return array_variable
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ jupyter==1.0.0
 jupyter-client==5.2.3
 jupyter-console==5.2.0
 jupyter-core==4.4.0
-jupyter-geppetto==1.0.0
+jupyter-geppetto==1.0.1
 kiwisolver==1.0.1
 lxml==4.2.4
 MarkupSafe==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ defusedxml==0.5.0
 Deprecated==1.2.6
 entrypoints==0.2.3
 filelock==3.0.12
-h5py==2.9.0
-hdmf==1.1.2
+h5py==2.10.0
+hdmf==1.5.4
 holoviews==1.10.6
 html5lib==1.0.1
 idna==2.8
@@ -54,11 +54,11 @@ nbformat==4.4.0
 ndx-grayscalevolume==0.0.2
 nose==1.3.7
 notebook==5.6.0
-numpy==1.15.1
+numpy==1.18.1
 nwbwidgets==0.0.2
 ordered-set==3.0.1
 packaging==19.1
-pandas==0.25.0
+pandas==0.25.3
 pandocfilters==1.4.2
 param==1.9.1
 parso==0.3.1
@@ -77,10 +77,10 @@ pyecore==0.10.2
 pygeppetto==0.6.0
 Pygments==2.2.0
 pymultigen==0.2.0
-pynwb==1.0.3
+pynwb==1.2.1
 pyparsing==2.2.0
 pyrsistent==0.15.4
-python-dateutil==2.7.3
+python-dateutil==2.8.0
 pythreejs==2.1.1
 pytz==2018.5
 pyviz-comms==0.7.2

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ setuptools.setup(
         'redis==2.10.6',
         'seaborn==0.8.1',
         'uuid==1.30',
-        'pynwb>=1.0.3',
+        'pynwb>=1.2.1',
         'imageio>=2.5.0',
         'quantities>=0.12.3',
-        'hdmf==1.1.2',
+        'hdmf==1.5.4',
         'nwbwidgets==0.0.2'
     ],
 )

--- a/test/test_nwb_data_manager.py
+++ b/test/test_nwb_data_manager.py
@@ -1,10 +1,12 @@
 import pytest
-from pygeppetto.model.types import ImportType
+import os
 
 from nwb_explorer.nwb_data_manager import NWBDataManager
 
 from pygeppetto.services.model_interpreter import get_model_interpreter
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
 
 @pytest.fixture
 def nwb_data_manager():
@@ -12,11 +14,11 @@ def nwb_data_manager():
 
 
 def test_get_project_from_url(nwb_data_manager):
-    fname = 'nwb_files/time_series_data.nwb'
+    fname = os.path.join(HERE, 'nwb_files/time_series_data.nwb')
     project = nwb_data_manager.get_project_from_url(fname)
     assert project.geppettoModel
     library = project.geppettoModel.variables[0].types[0].eContainer()
     assert library
-    assert library.id == 'nwblib'
+    assert library.id == 'nwbfile'
     model_interpreter = get_model_interpreter(library.id)
     assert model_interpreter


### PR DESCRIPTION
Update pynwb to 1.2.1. Update dependencies pandas, numpy, python-dateutil, h5py, hdmf to match versions in pynwb 1.2.1.

Removes outdated imports in mappers file