### PR TITLE
Update to allow cached extensions to be loaded

### DIFF
--- a/nwb_explorer/nwb_model_interpreter/nwb_reader.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_reader.py
@@ -110,7 +110,7 @@ class NWBReader:
             try:
 
 
-                io = NWBHDF5IO(nwbfile_or_path, 'r')
+                io = NWBHDF5IO(nwbfile_or_path, 'r', load_namespaces=True)
                 nwbfile = io.read()
             except Exception  as e:
                 raise ValueError('Error reading the NWB file.', e.args)


### PR DESCRIPTION
Fixes #151

Note: tested with development and master branch. Opening a PR to master as there are other fixes in progress on development. 

An example of an NWB file with bundled extensions is here: https://github.com/OpenSourceBrain/NWBShowcase/blob/master/ScholzEtAl2018/ScholzEtAl2018_AML175_moving_BrainScanner20180223_141721.nwb