### PR TITLE
Update NWB_WEBSITE URL to point to GitHub

### DIFF
--- a/webapp/components/constants.js
+++ b/webapp/components/constants.js
@@ -28,4 +28,4 @@ export const APPBAR_CONSTANTS = {
   NEW_PAGE: 'NEW_PAGE'
 }
 
-export const NWB_WEBSITE = "http://nwb.org"
+export const NWB_WEBSITE = "https://github.com/MetaCell/nwb-explorer/"


### PR DESCRIPTION
Very minor change, just updates the URL. (nwb.org is the website for the standard etc.)