### PR TITLE
chore(pydeps): bump nwbwidgets to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 imageio==2.5.0
 jupyter_geppetto==1.1.1
-nwbwidgets==0.4.0
+nwbwidgets==0.7.0
 pyecore==0.11.6
 pygeppetto==0.8.0
 pynwb==1.3.0


### PR DESCRIPTION
This is the latest version currently.

Fixes https://github.com/MetaCell/nwb-explorer/issues/236

I tested the new version out with some example files, and the widgets are still identical to what version 0.4.0 uses. NWB Explorer doesn't use any thing apart from the `nwb2widget` function, so this is quite a safe update.