### PR TITLE
Display object contents in details tab

### DIFF
--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -287,6 +287,8 @@ class VectorDataMapper(NWBGeppettoMapper):
 
     def get_value(self, v):
         if is_metadata(v):
+            if hasattr(v, 'decode'):
+                return Text(str(v.decode()))
             return Text(str(v))
         if id(v) in self.created_variables:
             return Pointer(path=self.created_variables[id(v)].getPath())

--- a/webapp/components/Metadata.js
+++ b/webapp/components/Metadata.js
@@ -66,8 +66,7 @@ export default class Metadata extends React.Component {
       } else if (variableType.getChildren && variableType.getChildren()) {
         metadata = variable.getType().getChildren().filter(v => v.getType().getName() == 'Text').map(v => this.formatField(prettyLabel(v.getId()), this.prettyContent(v.getInitialValue().value.text)));
       } else if (variableType.getName() == 'Simple Array') {
-        metadata = variable.getInitialValue().value.elements.join(',');
-        console.log('Array:', metadata);
+        metadata = variable.getInitialValue().value.elements.map(v => v['text'] || v).join(', ');
       } else {
         console.debug('Unsupported variable', variable)
       }


### PR DESCRIPTION
Some data fields are displayed in the details tab as [object Object]. Examples of where this occurs are in the `units.columns`, `electrodes.columns`, and `intervals.epochs.columns` parts of these example files from [dandiset 000006](https://dandiarchive.s3.amazonaws.com/blobs/063/b97/063b9771-b0c0-4b84-8b7d-fb52929b3087) and [dandiset 000049](https://dandiarchive.s3.amazonaws.com/blobs/2c5/2a3/2c52a341-bb7f-433f-9ade-340f1bb0bf75) 

This change would display the object text contents instead.

Current display
![example_current_object_display](https://user-images.githubusercontent.com/40640337/124933414-df278480-dfd1-11eb-8151-6ba700ad4249.png)

Updates
![example_new_object_display](https://user-images.githubusercontent.com/40640337/124934008-5bba6300-dfd2-11eb-84cd-93e07b2df643.png)




