### PR TITLE
Add support for plotting all data from 2D time series

### DIFF
--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -18,7 +18,6 @@ from pygeppetto.model.types.types import TextType, ImportType, CompositeType
 from pygeppetto.model.values import Image, Text, ImportValue, StringArray
 from pygeppetto.model.variables import Variable, TypeToValueMap
 
-
 nwb_geppetto_mappers = []
 
 
@@ -32,6 +31,12 @@ def is_collection(value):
 
 def is_array(value):
     return isinstance(value, (np.ndarray, Dataset))
+
+
+def is_multidimensional_data(value):
+    """ Use this function to decide whether to split up the data into multiple rows or not """
+    image_types = ('OpticalSeries', 'TwoPhotonSeries', 'ImageMaskSeries', 'VectorData')  # VectorData in PlaneSeg
+    return hasattr(value, 'data') and len(value.data.shape) > 1 and not (value.neurodata_type in image_types)
 
 
 class MapperType(type):
@@ -139,7 +144,7 @@ class GenericCompositeMapper(NWBGeppettoMapper):
         return self.single_id(obj_id)
 
     def create_type(self, pynwb_obj, type_id=None, type_name=None):
-        if id(pynwb_obj) in self.created_types:
+        if id(pynwb_obj) in self.created_types and not is_multidimensional_data(pynwb_obj):
             return self.created_types[id(pynwb_obj)]
         obj_type = CompositeType(id=type_id, name=type_name, abstract=False)
 
@@ -188,9 +193,18 @@ class GenericCompositeMapper(NWBGeppettoMapper):
                     logging.debug(f'No mappers are defined for: {value}')
                 continue
 
-            variable = supportingmapper.create_variable(self.sanitize(key), value, pynwb_obj)
-            self.created_variables[id(value)] = variable
-            obj_type.variables.append(variable)
+            if is_multidimensional_data(value):
+                for index in range(value.data.shape[1]):  # loop through data rows to make separate variables
+                    name = f"{self.sanitize(key)}_row{index:02}"  # pad row name so ordered correctly in list view
+                    variable = supportingmapper.create_variable(name, value, pynwb_obj)
+                    self.created_variables[id(value.data[:, index])] = variable
+                    obj_type.variables.append(variable)
+            elif is_multidimensional_data(pynwb_obj) and key == 'data':
+                continue  # create data variable in TimeSeriesMapper.modify_type instead
+            else:
+                variable = supportingmapper.create_variable(self.sanitize(key), value, pynwb_obj)
+                self.created_variables[id(value)] = variable
+                obj_type.variables.append(variable)
 
     def get_object_items(self, pynwb_obj):
         obj_dict = pynwb_obj.fields if hasattr(pynwb_obj, 'fields') else pynwb_obj
@@ -319,6 +333,13 @@ class TimeseriesMapper(GenericCompositeMapper):
         if pynwb_obj.timestamp_link:  # A set with linked timestamps
             variable = self.model_factory.create_text_variable(id="timestamp_link",
                                                                text=next(iter(pynwb_obj.timestamp_link)).name)
+            geppetto_composite_type.variables.append(variable)
+
+        if is_multidimensional_data(pynwb_obj):  # if multidimensional data, select data from relevant row
+            index = self.type_ids[pynwb_obj.name]
+            timeseries_dict = {**pynwb_obj.fields, 'data': pynwb_obj.data[:, index]}
+            import_val = ImportValueMapper.create_import_value(timeseries_dict)
+            variable = self.model_factory.create_state_variable(id="data", initialValue=import_val)
             geppetto_composite_type.variables.append(variable)
 
     def get_object_items(self, pynwb_obj):

--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -342,6 +342,9 @@ class TimeseriesMapper(GenericCompositeMapper):
             variable = self.model_factory.create_state_variable(id="data", initialValue=import_val)
             geppetto_composite_type.variables.append(variable)
 
+            message = f"contains values from row {index} of {pynwb_obj.name}"
+            UnsupportedMapper.handle_unsupported(geppetto_composite_type, self.model_factory, message)
+
     def get_object_items(self, pynwb_obj):
         return ((key, value) for key, value in super().get_object_items(pynwb_obj) if key != 'timestamp_link')
 

--- a/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_geppetto_mappers.py
@@ -35,8 +35,9 @@ def is_array(value):
 
 def is_multidimensional_data(value):
     """ Use this function to decide whether to split up the data into multiple rows or not """
-    image_types = ('OpticalSeries', 'TwoPhotonSeries', 'ImageMaskSeries', 'VectorData')  # VectorData in PlaneSeg
-    return hasattr(value, 'data') and len(value.data.shape) > 1 and not (value.neurodata_type in image_types)
+    image_types = ('ImageSeries', 'OpticalSeries', 'TwoPhotonSeries', 'ImageMaskSeries', 'VectorData')
+    return hasattr(value, 'data') and value.data is not None and len(value.data.shape) > 1 and not(
+            value.neurodata_type in image_types)
 
 
 class MapperType(type):

--- a/nwb_explorer/nwb_model_interpreter/nwb_model_interpreter.py
+++ b/nwb_explorer/nwb_model_interpreter/nwb_model_interpreter.py
@@ -97,6 +97,14 @@ class NWBModelInterpreter(ModelInterpreter):
                         time_series_value.value[index] = time_series_value.value[index] * time_series.conversion
                 stringV = str(time_series_value)
                 return time_series_value
+        elif isinstance(nwb_obj, dict):
+            plottable_timeseries = NWBReader.get_mono_dimensional_timeseries_aux(nwb_obj['data'])
+            unit = guess_units(nwb_obj['unit'])
+            time_series_value = GeppettoModelFactory.create_time_series(plottable_timeseries[0], unit)
+            if nwb_obj['conversion'] is not None:
+                for index, item in enumerate(time_series_value.value):
+                    time_series_value.value[index] = time_series_value.value[index] * nwb_obj['conversion']
+            return time_series_value
         else:
             # TODO handle other possible ImportValue(s)
             pass


### PR DESCRIPTION
Addresses #259. Splits 2D time series data into separate variables so each row can be plotted individually. This does not split up any 3D ImageSeries data types.
 
![example_2d_timeseries_plot](https://user-images.githubusercontent.com/40640337/129782192-5e96489d-fec0-4604-b5e9-aa0a319837fa.png)

Example above from [this file](https://dandiarchive.s3.amazonaws.com/blobs/2c5/2a3/2c52a341-bb7f-433f-9ade-340f1bb0bf75) from dandiset 00049.